### PR TITLE
docs: update Alpine package repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ On NetBSD a pre-compiled binary is available from the official repositories. To 
 pkgin install seaward
 ```
 
-An Alpine Linux package is also available in the `testing` repository:
+An Alpine Linux package is also available in the `community` repository:
 ``` console
 apk add seaward
 ```


### PR DESCRIPTION
Hi! I'm the maintainer of the Alpine Linux package for seaward. Seaward is now in Alpine's community repository ([aports commit](https://gitlab.alpinelinux.org/alpine/aports/-/commit/7b4855a0f896a4f2bcaf6af36d6a94cfc0b1b69b)).

On an unrelated note, Alpine currently patches the Cargo.lock file to use version 0.2.155 of the libc crate instead of 0.2.147. When you next release a new version of seaward, it would be great if you could `cargo update` the libc crate first so we no longer have to patch it.

Thanks!